### PR TITLE
Update to skel standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -24,5 +24,4 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
-
+#### Known Compatibility Issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 cache:
 - bundler
+before_install:
+  gem install bundler -v 1.15
 install:
 - bundle install
 rvm:
@@ -8,10 +10,12 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
     - smbambling@gmail.com
+    - sensu-plugin@sensu-plugins.io
     on_success: change
     on_failure: always
 script:
@@ -28,7 +32,5 @@ deploy:
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0
-    repo: smbambling/sensu-plugins-switchvox
-addons:
-    code_climate:
-          repo_token:
+    rvm: 2.4.1
+    repo: sensu-plugins/sensu-plugins-switchvox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 0.0.1 - 2016-08-09
+This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+
+## [Unreleased]
+### Breaking Change
+- Remove support for Ruby 1.9.3 (@eheydrick)
+
+### Added
+- Testing on Ruby 2.4.1 (@eheydrick)
+
+### Changed
+- Misc updates to boilerplate files to bring up to skel standards (@eheydrick)
+
+## 0.0.1 - 2017-03-22
 ### Added
 - Initial release
+
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-switchvox/compare/0.0.1...HEAD

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
-gem 'codeclimate-test-reporter', group: :test, require: nil
 
-# Specify your gem's dependencies in sensu-plugins-switchvox.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Build Status](https://travis-ci.org/smbambling/sensu-plugins-switchvox.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-switchvox)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-switchvox.svg)](http://badge.fury.io/rb/sensu-plugins-switchvox)
-[![Code Climate](https://codeclimate.com/github/smbambling/sensu-plugins-switchvox/badges/gpa.svg)](https://codeclimate.com/github/smbambling/sensu-plugins-switchvox)
-[![Test Coverage](https://codeclimate.com/github/smbambling/sensu-plugins-switchvox/badges/coverage.svg)](https://codeclimate.com/github/smbambling/sensu-plugins-switchvox)
-[![Dependency Status](https://gemnasium.com/smbambling/sensu-plugins-switchvox.svg)](https://gemnasium.com/smbambling/sensu-plugins-switchvox)
+[![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-switchvox.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-switchvox)
 
 ## Functionality
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/sensu-plugins-switchvox.gemspec
+++ b/sensu-plugins-switchvox.gemspec
@@ -2,20 +2,15 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
+require_relative 'lib/sensu-plugins-switchvox'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-switchvox'
-else
-  require_relative 'lib/sensu-plugins-switchvox'
-end
-
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
   s.date                   = Date.today.to_s
   s.description            = 'Sensu plugins for Switchvox'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-switchvox'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -27,7 +22,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   s.summary                = 'Sensu plugins for Switchvox'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsSwitchvox::Version::VER_STRING
@@ -35,13 +30,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
   s.add_runtime_dependency 'snmp',         '1.2.0'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
-  s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
+  s.add_development_dependency 'bundler',                   '~> 1.15'
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'pry',                       '~> 0.10'
-  s.add_development_dependency 'rake',                      '~> 10.5'
+  s.add_development_dependency 'rake',                      '~> 12.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Related to https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/23

Includes removing Ruby 1.9.3 support and adding 2.4.1 for https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/27

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Bring switchvox in line with other plugins.

#### Known Compatablity Issues

Drops support for Ruby 1.9.3.
